### PR TITLE
add setlocal norelativenumber (nornu) to s:Init()

### DIFF
--- a/plugin/matrix.vim
+++ b/plugin/matrix.vim
@@ -190,7 +190,7 @@ function! s:Init()
    " close all but window 1, which is the new window
    only
 
-   setl bh=delete bt=nofile ma nolist nonu noro noswf tw=0 nowrap
+   setl bh=delete bt=nofile ma nolist nonu nornu noro noswf tw=0 nowrap
 
    " Set GUI options
    if has('gui')


### PR DESCRIPTION
This pull request avoids flickering relative numbers if 'relativenumber' is set globally.

To reproduce flickering relative numbers without this patch:

vim --clean matrix.vim
:set rnu
:so %
:Matrix
